### PR TITLE
Bson

### DIFF
--- a/lib/fs-adapter.js
+++ b/lib/fs-adapter.js
@@ -2,22 +2,32 @@ const pathLib = require('path');
 const Stream = require('stream');
 const fs = require('fs-extra');
 const recursive = require('recursive-readdir');
-
+const bson = require('bson');
 class FSAdapter {
     constructor() {
         this._wasInit = false;
+        this._parse = JSON.parse;
+        this._stringify = JSON.stringify;
     }
 
     async init(config, directories, bootstrap = false) {
         if (!this._wasInit) {
             this._wasInit = true;
             this._baseDirectory = config.baseDirectory;
-            this._cleanPathRegex = new RegExp(this._baseDirectory, 'g'); 
-            if (bootstrap) {
-                await Promise.all(Object.values(directories).map(dirName => fs.ensureDir(pathLib.join(this._baseDirectory, dirName))));
+            this._cleanPathRegex = new RegExp(this._baseDirectory, 'g');
+            if (config.binary) {
+                this._parse = (data) => {
+                    const ret = bson.deserialize(data);
+                    return ret.data;
+                };
+                this._stringify = data => bson.serialize({ data });
             }
         }
+        if (bootstrap) {
+            await Promise.all(Object.values(directories).map(dirName => fs.ensureDir(pathLib.join(this._baseDirectory, dirName))));
+        }
     }
+
 
     async put(options) {
         return this._put({ ...this._parsePath(options.path), data: options.data });
@@ -25,13 +35,13 @@ class FSAdapter {
 
     async _put(options) {
         await fs.ensureDir(pathLib.join(this._baseDirectory, options.directoryName));
-        await fs.writeJson(pathLib.join(this._baseDirectory, options.directoryName, options.fileName), options.data);
+        await fs.writeFile(pathLib.join(this._baseDirectory, options.directoryName, options.fileName), this._stringify(options.data));
         return { path: pathLib.join(options.directoryName, options.fileName) };
     }
 
     async get(options) {
-        const res = await fs.readJson(pathLib.join(this._baseDirectory, options.path));
-        return res;
+        const res = await fs.readFile(pathLib.join(this._baseDirectory, options.path));
+        return this._parse(res);
     }
 
     _parsePath(fullPath) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -323,6 +323,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -346,6 +351,24 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "bson": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.2.tgz",
+      "integrity": "sha512-rBdCxMBCg2aR420e1oKUejjcuPZLTibA7zEhWAlliFWEwzuBCC9Dkp5r7VFFIQB2t1WVsvTbohry575mc7Xw5A==",
+      "requires": {
+        "buffer": "^5.1.0",
+        "long": "^4.0.0"
+      }
+    },
+    "buffer": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1213,6 +1236,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "ignore": {
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
@@ -1642,6 +1670,11 @@
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
       "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
       "dev": true
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bson": "^4.0.2",
     "fs-extra": "^7.0.0",
     "recursive-readdir": "^2.2.2",
     "uuid": "^3.3.2"

--- a/tests/test-binary.js
+++ b/tests/test-binary.js
@@ -1,0 +1,174 @@
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+const { expect } = chai;
+const moment = require('moment');
+const path = require('path');
+const fs = require('fs-extra');
+const baseDir = 'storage/nfs/test/';
+const uuid = require('uuid/v4');
+const adapter = require('../lib/fs-adapter');
+const DIR_NAMES = {
+    HKUBE: 'data/hkube',
+    HKUBE_RESULTS: 'data/hkube-results',
+    HKUBE_METADATA: 'data/hkube-metadata',
+    HKUBE_STORE: 'data/hkube-store',
+    HKUBE_EXECUTION: 'data/hkube-execution'
+};
+const DateFormat = 'YYYY-MM-DD';
+
+describe('fs-adapter', () => {
+    before(async () => {
+        const options = {
+            baseDirectory: baseDir,
+            binary: true
+        };
+        await adapter.init(options, DIR_NAMES, true);
+    });
+    describe('put', () => {
+        it('put and get same value', async () => {
+            const jobId = uuid();
+            const link = await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, uuid()), data: 'test' });
+            const res = await adapter.get(link);
+            expect(res).to.equal('test');
+        });
+        it('put and get results same value', async () => {
+            const link = await adapter.put({ path: path.join(DIR_NAMES.HKUBE_RESULTS, moment().format(DateFormat), uuid()), data: 'test-result' });
+            const res = await adapter.get(link);
+            expect(res).to.equal('test-result');
+        });
+        it('put and get results null', async () => {
+            const link = await adapter.put({ path: path.join(DIR_NAMES.HKUBE_RESULTS, moment().format(DateFormat), uuid()), data: null });
+            const res = await adapter.get(link);
+            expect(res).to.equal(null);
+        });
+        it('put and get results []', async () => {
+            const link = await adapter.put({ path: path.join(DIR_NAMES.HKUBE_RESULTS, moment().format(DateFormat), uuid()), data: [] });
+            const res = await adapter.get(link);
+            expect(res).to.deep.equal([]);
+        });
+        it('put and get results 33', async () => {
+            const link = await adapter.put({ path: path.join(DIR_NAMES.HKUBE_RESULTS, moment().format(DateFormat), uuid()), data: 33 });
+            const res = await adapter.get(link);
+            expect(res).to.equal(33);
+        });
+        it('put and delete', async () => {
+            const link = await adapter.put({ path: path.join(DIR_NAMES.HKUBE_RESULTS, moment().format(DateFormat), uuid()), data: 33 });
+            const res = await fs.pathExists(path.join(baseDir, link.path));
+            expect(res).to.equal(true);
+
+            await adapter.delete(link);
+            const res1 = await fs.pathExists(path.join(baseDir, link.path));
+            expect(res1).to.equal(false);
+        });
+        it('put and list', async () => {
+            const jobId = uuid();
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, uuid()), data: 'test1' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, uuid()), data: 'test2' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, uuid()), data: 'test3' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, uuid()), data: 'test4' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, uuid()), data: 'test5' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, uuid()), data: 'test6' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, uuid()), data: 'test7' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, uuid()), data: 'test8' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, uuid()), data: 'test9' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, uuid()), data: 'test10' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, uuid()), data: 'test11' });
+
+            const res = await adapter.list({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId) });
+            expect(res.length).to.equal(11);
+        });
+        it('put and list with prefix', async () => {
+            const jobId = uuid();
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'test1' + uuid()), data: 'test1' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'test2' + uuid()), data: 'test2' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'test3' + uuid()), data: 'test3' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'test4' + uuid()), data: 'test4' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'test5' + uuid()), data: 'test5' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'test6' + uuid()), data: 'test6' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'test7' + uuid()), data: 'test7' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'test8' + uuid()), data: 'test8' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'test9' + uuid()), data: 'test9' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'test10' + uuid()), data: 'test10' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'test11' + uuid()), data: 'test11' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'xx' + uuid()), data: 'test11' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'dd' + uuid()), data: 'test11' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'ff' + uuid()), data: 'test11' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'gg' + uuid()), data: 'test11' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'f1', 'xx' + uuid()), data: 'test11' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'f1', 'dd' + uuid()), data: 'test11' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'f1', 'ff' + uuid()), data: 'test11' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'f1', 'gg' + uuid()), data: 'test11' });
+            const res = await adapter.list({ path: path.join(DIR_NAMES.HKUBE, moment().format(DateFormat), jobId, 'test') });
+            expect(res.length).to.equal(11);
+        });
+        it('put and list prefix', async () => {
+            const jobId = uuid();
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment('2015-01-27').format(DateFormat), jobId, 'test1' + uuid()), data: 'test1' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment('2015-01-26').format(DateFormat), jobId, 'test2' + uuid()), data: 'test2' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment('2015-01-25').format(DateFormat), jobId, 'test3' + uuid()), data: 'test3' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment('2015-01-24').format(DateFormat), jobId, 'test4' + uuid()), data: 'test4' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment('2015-01-23').format(DateFormat), jobId, 'test5' + uuid()), data: 'test5' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment('2015-01-22').format(DateFormat), jobId, 'test6' + uuid()), data: 'test6' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, moment('2015-01-21').format(DateFormat), jobId, 'test7' + uuid()), data: 'test7' });
+
+            const res = await adapter.listPrefixes({ path: DIR_NAMES.HKUBE });
+            expect(res.includes('2015-01-27')).to.be.true;
+            expect(res.includes('2015-01-26')).to.be.true;
+            expect(res.includes('2015-01-25')).to.be.true;
+            expect(res.includes('2015-01-24')).to.be.true;
+            expect(res.includes('2015-01-23')).to.be.true;
+            expect(res.includes('2015-01-22')).to.be.true;
+            expect(res.includes('2015-01-21')).to.be.true;
+        }).timeout(50000);
+        it('list and get', async () => {
+            const jobId = uuid();
+            const folder = uuid();
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, folder, jobId, 'test1' + uuid()), data: 'test1' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, folder, jobId, 'test2' + uuid()), data: 'test2' });
+
+            const res = await adapter.list({ path: path.join(DIR_NAMES.HKUBE, folder) });
+            expect(res.length).to.eql(2);
+            const file1 = await adapter.get(res[0]);
+            expect(file1).to.exist;
+            const file2 = await adapter.get(res[1]);
+            expect(file2).to.exist;
+        }).timeout(50000);
+        it('list and get prefix', async () => {
+            const jobId = uuid();
+            const folder = uuid();
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, folder, jobId, 'test1' + uuid()), data: 'test1' });
+            await adapter.put({ path: path.join(DIR_NAMES.HKUBE, folder, jobId, 'test2' + uuid()), data: 'test2' });
+
+            const res = await adapter.list({ path: path.join(DIR_NAMES.HKUBE, folder, jobId, 'te') });
+            expect(res.length).to.eql(2);
+            const file1 = await adapter.get(res[0]);
+            expect(file1).to.exist;
+            const file2 = await adapter.get(res[1]);
+            expect(file2).to.exist;
+        }).timeout(50000);
+    });
+    describe('Stream', () => {
+        it('put and get results same value', async () => {
+            return new Promise(async (resolve) => {
+                const fileOut = path.join(adapter._baseDirectory, DIR_NAMES.HKUBE_STORE, 'stream-out.yml');
+                const readStream = fs.createReadStream('tests/mocks/stream.yml');
+                const fileInPath = path.join(DIR_NAMES.HKUBE_STORE, 'stream-in.yml');
+                const link = await adapter.putStream({ path: fileInPath, data: readStream });
+                const readable = await adapter.getStream(link);
+                const writable = fs.createWriteStream(fileOut);
+                const stream = readable.pipe(writable);
+                stream.on('finish', () => {
+                    const fileIn = path.join(adapter._baseDirectory, fileInPath);
+                    const inFile = fs.readFileSync(fileIn, 'utf8');
+                    const outFile = fs.readFileSync(fileOut, 'utf8');
+                    expect(inFile).to.equal(outFile);
+                    resolve();
+                });
+            });
+        });
+    });
+    after(() => {
+        Object.values(DIR_NAMES).forEach(dir => fs.removeSync(path.join(baseDir, dir)));
+    });
+});


### PR DESCRIPTION
Adds bson (binary) support to adapter.
Can be switched on with the ```fs.config.binary=true``` option

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-hpc/fs-adapter.hkube/6)
<!-- Reviewable:end -->
